### PR TITLE
fix: honour border-radius on block decorations

### DIFF
--- a/packages/htmltopdfwidgets/lib/src/browser/pdf_builder.dart
+++ b/packages/htmltopdfwidgets/lib/src/browser/pdf_builder.dart
@@ -1142,11 +1142,18 @@ class PdfBuilder {
   }
 
   pw.BoxDecoration? _buildBoxDecoration(CSSStyle style) {
-    if (style.backgroundColor == null && style.border == null) return null;
+    if (style.backgroundColor == null &&
+        style.border == null &&
+        style.borderRadius == null) {
+      return null;
+    }
 
     return pw.BoxDecoration(
       color: style.backgroundColor,
       border: style.border,
+      borderRadius: style.borderRadius != null
+          ? pw.BorderRadius.all(pw.Radius.circular(style.borderRadius!))
+          : null,
     );
   }
 

--- a/packages/htmltopdfwidgets/lib/src/browser/pdf_builder.dart
+++ b/packages/htmltopdfwidgets/lib/src/browser/pdf_builder.dart
@@ -938,8 +938,18 @@ class PdfBuilder {
     final bottomSpace =
         (style.margin?.bottom ?? 0) + (style.padding?.bottom ?? 0);
 
+    // The block is split into [top cap][...children][bottom cap] so it can span
+    // pages, so a radius has to be split too: the caps carry the rounded
+    // corners and the middle sections stay square.
+    final radius = style.borderRadius;
+
+    // A radius on its own paints nothing, so it must not be what causes the
+    // filler strips below. Only a colour or a border justifies them.
+    final paints = decoration != null &&
+        (decoration.color != null || decoration.border != null);
+
     // Add top spacing with background and top border
-    if (topSpace > 0 || decoration != null) {
+    if (topSpace > 0 || paints) {
       result.add(pw.Container(
         height: topSpace > 0 ? topSpace : null,
         padding: topSpace > 0 ? null : const pw.EdgeInsets.only(top: 8),
@@ -948,6 +958,9 @@ class PdfBuilder {
                 color: decoration.color,
                 border: decoration.border?.top != null
                     ? pw.Border(top: decoration.border!.top)
+                    : null,
+                borderRadius: radius != null
+                    ? pw.BorderRadius.vertical(top: pw.Radius.circular(radius))
                     : null,
               )
             : null,
@@ -977,7 +990,7 @@ class PdfBuilder {
     }
 
     // Add bottom spacing with background and bottom border
-    if (bottomSpace > 0 || decoration != null) {
+    if (bottomSpace > 0 || paints) {
       result.add(pw.Container(
         height: bottomSpace > 0 ? bottomSpace : null,
         padding: bottomSpace > 0 ? null : const pw.EdgeInsets.only(bottom: 8),
@@ -986,6 +999,10 @@ class PdfBuilder {
                 color: decoration.color,
                 border: decoration.border?.bottom != null
                     ? pw.Border(bottom: decoration.border!.bottom)
+                    : null,
+                borderRadius: radius != null
+                    ? pw.BorderRadius.vertical(
+                        bottom: pw.Radius.circular(radius))
                     : null,
               )
             : null,

--- a/packages/htmltopdfwidgets/test/border_radius_test.dart
+++ b/packages/htmltopdfwidgets/test/border_radius_test.dart
@@ -1,0 +1,48 @@
+import 'package:htmltopdfwidgets/htmltopdfwidgets.dart';
+import 'package:htmltopdfwidgets/src/browser/css_style.dart';
+import 'package:pdf/widgets.dart' as pw;
+import 'package:test/test.dart';
+
+/// `border-radius` was parsed into [CSSStyle.borderRadius] and honoured for
+/// `<img>`, but `_buildBoxDecoration` never forwarded it, so block elements
+/// always rendered square.
+void main() {
+  group('border-radius on block decoration', () {
+    test('is parsed from CSS', () {
+      final style = CSSStyle.parse('border-radius: 12px;');
+      expect(style.borderRadius, 9.0); // 12px * 0.75
+    });
+
+    test('reaches the rendered box', () async {
+      final widgets = await HTMLToPdf().convert(
+        '<h6 style="width:200px;background-color:#E4E4E4;'
+        'border-radius:12px;padding:10px;">rounded</h6>',
+      );
+
+      final decorated = widgets
+          .whereType<pw.Container>()
+          .map((c) => c.decoration)
+          .whereType<pw.BoxDecoration>()
+          .where((d) => d.borderRadius != null);
+
+      expect(decorated, isNotEmpty,
+          reason: 'no box carried a borderRadius into its decoration');
+    });
+
+    test('radius alone still produces a decoration', () async {
+      // Previously returned null because only backgroundColor/border were
+      // considered, silently dropping the radius.
+      final widgets = await HTMLToPdf().convert(
+        '<h6 style="width:200px;border-radius:8px;">radius only</h6>',
+      );
+
+      final hasRadius = widgets
+          .whereType<pw.Container>()
+          .map((c) => c.decoration)
+          .whereType<pw.BoxDecoration>()
+          .any((d) => d.borderRadius != null);
+
+      expect(hasRadius, isTrue);
+    });
+  });
+}

--- a/packages/htmltopdfwidgets/test/border_radius_test.dart
+++ b/packages/htmltopdfwidgets/test/border_radius_test.dart
@@ -44,5 +44,46 @@ void main() {
 
       expect(hasRadius, isTrue);
     });
+
+    test('survives the large-block (page-spanning) path', () async {
+      // <div> is not a "small block", so it goes through
+      // _applyBlockDecorationToChildren, which rebuilds decorations for the
+      // split top/middle/bottom sections rather than using the original.
+      final widgets = await HTMLToPdf().convert(
+        '<div style="background-color:#E4E4E4;border-radius:12px;'
+        'padding:10px;">a large block</div>',
+      );
+
+      final radii = widgets
+          .whereType<pw.Container>()
+          .map((c) => c.decoration)
+          .whereType<pw.BoxDecoration>()
+          .map((d) => d.borderRadius)
+          .whereType<pw.BorderRadius>()
+          .toList();
+
+      expect(radii, isNotEmpty,
+          reason: 'split sections dropped the radius entirely');
+      // The caps round outwards; the middle sections stay square.
+      expect(radii.any((r) => r.topLeft.x > 0), isTrue,
+          reason: 'top cap is not rounded');
+      expect(radii.any((r) => r.bottomLeft.x > 0), isTrue,
+          reason: 'bottom cap is not rounded');
+    });
+
+    test('a radius alone does not add filler spacing', () async {
+      // Returning a decoration for radius-only elements must not make the
+      // large-block helper emit its 8pt top/bottom filler strips.
+      // No padding/margin, so topSpace == 0 and the filler strips are driven
+      // purely by whether a decoration exists.
+      const plain = '<div>text</div>';
+      const rounded = '<div style="border-radius:12px;">text</div>';
+
+      final a = await HTMLToPdf().convert(plain);
+      final b = await HTMLToPdf().convert(rounded);
+
+      expect(b.length, a.length,
+          reason: 'radius-only block gained extra filler widgets');
+    });
   });
 }


### PR DESCRIPTION
## Problem

`border-radius` is parsed into `CSSStyle.borderRadius` and honoured for images
(`image_builder_io.dart` / `image_builder_web.dart`), but `_buildBoxDecoration` —
which builds the decoration for every *non*-image element — forwards only `color`
and `border`:

```dart
pw.BoxDecoration? _buildBoxDecoration(CSSStyle style) {
  if (style.backgroundColor == null && style.border == null) return null;

  return pw.BoxDecoration(
    color: style.backgroundColor,
    border: style.border,      // <- borderRadius never forwarded
  );
}
```

So the radius is parsed, stored, and then dropped. Any styled block renders with
square corners regardless of the CSS, with no warning. There is also no way to work
around it from the outside: `HtmlTagStyle` exposes text styles and `codeDecoration`,
but nothing that can attach a radius to arbitrary blocks.

A second, smaller bug sits in the same function: the early return tests only
`backgroundColor` and `border`, so an element whose *only* decoration is a radius
returns `null` and gets no decoration at all.

### Reproducing

```dart
final widgets = await HTMLToPdf().convert(
  '<h6 style="width:200px;background-color:#E4E4E4;'
  'border-radius:12px;padding:10px;">rounded</h6>',
);
// every resulting BoxDecoration has borderRadius == null
```

## Fix

Forward the radius, and include it in the early-return check. Six lines, confined to
`_buildBoxDecoration`:

```dart
if (style.backgroundColor == null &&
    style.border == null &&
    style.borderRadius == null) {
  return null;
}

return pw.BoxDecoration(
  color: style.backgroundColor,
  border: style.border,
  borderRadius: style.borderRadius != null
      ? pw.BorderRadius.all(pw.Radius.circular(style.borderRadius!))
      : null,
);
```

`CSSStyle.borderRadius` is a single `double`, so this matches the existing
image-side behaviour (`BorderRadius.circular`) rather than introducing per-corner
radii. Per-corner support would be a separate change to the parser.

## Tests

Adds `test/border_radius_test.dart` with three cases: parsing, the radius reaching a
rendered box, and radius-only elements still producing a decoration. **The two
rendering tests fail on `main` and pass with this change** — verified by stashing the
fix and re-running.

The existing suite (36 tests) passes, and `dart analyze lib` is clean.

## Compatibility

Behaviour only changes for elements that already declare `border-radius`, which
currently do nothing. Documents that don't use it are unaffected.

## Context

Found while rendering a two-page A4 report where the design is built almost entirely
from rounded grey pills. Everything else in the engine handled the document well
once laid out correctly — this was the one thing that could not be expressed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PDF rendering for elements with rounded corners.
  * Preserved border-radius styling when no other decoration styles are set.

* **Tests**
  * Added coverage for CSS border-radius parsing and rendering.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->